### PR TITLE
Feature/spot user list

### DIFF
--- a/app/controllers/spots_controller.rb
+++ b/app/controllers/spots_controller.rb
@@ -4,16 +4,7 @@ class SpotsController < ApplicationController
   before_action :authorize_spot_owner, only: [:update, :destroy]
 
   def index
-    @spots = Spot.all
-    # This part related to the map to pass more info about the spots to the view
-    @markers = @spots.geocoded.map do |spot|
-      {
-    lat: spot.latitude,
-    lng: spot.longitude,
-    info_window_html: render_to_string(partial: "info_window", locals: { spot: spot }),
-    image_url: helpers.asset_url("https://res.cloudinary.com/dg5qvbxjp/image/upload/v1748375631/ChatGPT_Image_May_27_2025_at_02_53_12_PM_iz8dcr.png")
-  }
-    end
+     @spots = Spot.where.not(user_id: current_user.id)
     if params[:location].present?
       @spots = @spots.where("description ILIKE ? OR category ILIKE ?", "%#{params[:location]}%", "%#{params[:location]}%")
       # If you have an address or city field, use that instead!
@@ -26,6 +17,7 @@ class SpotsController < ApplicationController
   end
 
   def show
+    @spots = Spot.where.not(user_id: current_user.id).order(created_at: :desc)
   end
 
   def new

--- a/app/controllers/spots_controller.rb
+++ b/app/controllers/spots_controller.rb
@@ -4,7 +4,11 @@ class SpotsController < ApplicationController
   before_action :authorize_spot_owner, only: [:update, :destroy]
 
   def index
-     @spots = Spot.where.not(user_id: current_user.id)
+    if current_user
+      @spots = Spot.where.not(user_id: current_user.id).order(created_at: :desc)
+    else
+      @spots = Spot.order(created_at: :desc)
+    end
     if params[:location].present?
       @spots = @spots.where("description ILIKE ? OR category ILIKE ?", "%#{params[:location]}%", "%#{params[:location]}%")
       # If you have an address or city field, use that instead!

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[7.1].define(version: 2025_05_29_163608) do
+ActiveRecord::Schema[7.1].define(version: 2025_05_28_184136) do
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
 
@@ -77,7 +77,6 @@ ActiveRecord::Schema[7.1].define(version: 2025_05_29_163608) do
     t.string "address"
     t.float "latitude"
     t.float "longitude"
-    t.string "title"
     t.index ["user_id"], name: "index_spots_on_user_id"
   end
 


### PR DESCRIPTION
### Summary
This PR ensures that logged-in users no longer see their own spots in the index list. Unauthenticated visitors see all spots.

### Changes
- Added a condition in `SpotsController#index` to exclude spots from current_user
- Ordered the list by newest first

### How to test
- Log in → go to `/spots` → you should not see your own spots
- Log out → go to `/spots` → you should see all spots